### PR TITLE
PJ_SIM_CHATGPT_2023-56 [Code Reviewer] Format extracted commits to suitable structure for GPT prompt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,6 @@ LOG_LEVEL=debug
 WEBHOOK_PROXY_URL=
 
 # Go to github settings->developer settings->github app->general
+PRIVATE_KEY=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import { Probot } from 'probot';
 
+const MAX_PATCH_COUNT = process.env.MAX_PATCH_LENGTH
+  ? +process.env.MAX_PATCH_LENGTH
+  : Infinity;
+
 export = (app: Probot) => {
   app.on(
     ['pull_request.opened', 'pull_request.synchronize'],
@@ -7,12 +11,24 @@ export = (app: Probot) => {
       // Get current repository details
       const repo = context.repo();
 
+      //Check pull request event type
+      const pull_request = context.payload.pull_request;
+
+      if (
+        pull_request.state === 'closed' ||
+        pull_request.locked ||
+        pull_request.draft
+      ) {
+        console.log('Invalid pull request event');
+        throw new Error('Invalid pull request event');
+      }
+
       // Get commit data from current repository and pull request
       const data = await context.octokit.repos.compareCommits({
         owner: repo.owner,
         repo: repo.repo,
-        base: context.payload.pull_request.base.sha,
-        head: context.payload.pull_request.head.sha,
+        base: pull_request.base.sha,
+        head: pull_request.head.sha,
       });
 
       let { files: changedFiles, commits } = data.data;
@@ -33,7 +49,34 @@ export = (app: Probot) => {
           filesNames.includes(file.filename)
         );
       }
-      console.log('Changed Files: ', changedFiles);
+
+      if (!changedFiles?.length) {
+        throw new Error('No changes were made');
+      }
+
+      // Loop through the changed files to get commit patches to be fed in  chatGPT
+      for (let i = 0; i < changedFiles.length; i++) {
+        const file = changedFiles[i];
+        const patch = file.patch || '';
+
+        if (file.status !== 'modified' && file.status !== 'added') {
+          continue;
+        }
+
+        if (!patch || patch.length > MAX_PATCH_COUNT) {
+          console.log(`${file.filename} skipped due to large diff`);
+          continue;
+        }
+
+        console.log(patch);
+      }
+
+      await context.octokit.issues.createComment({
+        repo: repo.repo,
+        owner: repo.owner,
+        issue_number: context.pullRequest().pull_number,
+        body: JSON.stringify(changedFiles),
+      });
     }
   );
   // For more information on building apps:


### PR DESCRIPTION
## Links
https://framgiaph.backlog.com/view/PJ_SIM_CHATGPT_2023-56
## Description
- Format extracted commits to suitable structure for GPT prompt
- We can refer to the other reviewers way of formatting commits to feed to chatgpt prompt
## Notes
- run `npm run build` to build the bot
- run `npm start` after
## Screenshots
![image](https://github.com/rogeliojohnoliverio/sun-code-reviewer/assets/110364637/e7c7d1c3-424a-4aee-a225-45bc178551b7)
