### PR TITLE
PJ_SIM_CHATGPT_2023-62 [Code Reviewer] Integrate assessment of file diffs with ChatGPT

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -121,7 +121,8 @@ export const Bot = (app: Probot) => {
               body: res.includes(assessment.APPROVED)
                 ? `${assessment.APPROVED} :white_check_mark:`
                 : `### NEEDS REVIEW :bangbang: \n\n${res}`,
-              line: patch.split('\n').length - 1,
+              line:
+                patch.split('\n').length > 1 ? patch.split('\n').length - 1 : 1,
             });
           }
         } catch (e) {

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,0 +1,4 @@
+export const assessment = {
+  APPROVED: 'APPROVED',
+  NEEDS_REVIEW: 'NEEDS_REVIEW',
+} as const;

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -113,7 +113,7 @@ export class Prompts {
     $patch
     `;
 
-  triageFileDiff = `Below the summary, I would also like you to triage the diff as \`NEEDS_REVIEW\` or
+  assessFileDiff = `I would like you to triage the file changes as \`NEEDS_REVIEW\` or
     \`APPROVED\` based on the following criteria:
 
     - If the diff involves any modifications to the logic or functionality, even if they
@@ -136,5 +136,8 @@ export class Prompts {
     - Do not provide any reasoning why you triaged the diff as \`NEEDS_REVIEW\` or \`APPROVED\`.
     - Do not mention that these changes affect the logic or functionality of the code in
       the summary. You must only use the triage status format above to indicate that.
+
+    ## Changes made to \`$filename\` for your triage
+    $patch
     `;
 }


### PR DESCRIPTION
## Links
https://framgiaph.backlog.com/view/PJ_SIM_CHATGPT_2023-62
## Description
- Integrate assessment of file diffs with ChatGPT
- Should able to assess the file first before reviewing and suggesting code improvement and issues
- Add condition before review
## Notes
run `npm start`
## Screenshots
![markuphero-XndWkfSDTNpR9qs4aKin](https://github.com/rogeliojohnoliverio/sun-code-reviewer/assets/110364637/4ef8f6c9-81fb-4102-ba46-78bc4d92a352)
